### PR TITLE
Don't rely on REQUEST_URI

### DIFF
--- a/index.php
+++ b/index.php
@@ -229,8 +229,7 @@ function expand()
         $t .= '<div id="popup'.$i.$uniqueId.'" class="expand_content"' 
                 . 'style="max-height: 0px;"><div class="expand_contentwrap"' 
                 . ' style = "padding: ' . $contentpadding . '">';
-        $linkU =  $_SERVER['REQUEST_URI'];
-        $t .= '<div class="deepLink"><a href="' . $linkU . '#popup' 
+        $t .= '<div class="deepLink"><a href="#popup' 
                 . $i.$uniqueId . '">&#x1f517;</a></div>';
         if ($limitheight) {
             $t .= '<div style="height:' . $limitheight 


### PR DESCRIPTION
This variable might not be available on all supported Webservers (e.g. IIS depending on the setup), so we better avoid it.  We could use `$sn` and `$_SERVER[QUERY_STRING]`, but actually that is not even necessary since the browser is fine with a URL fragment.

---

Notice the PHP warning when working on the HTML attribute event handlers.