### PR TITLE
Don't override window.onload

### DIFF
--- a/expandcontract.js
+++ b/expandcontract.js
@@ -97,9 +97,9 @@ function ec_openFromHash() {
     hash = hash.replace("#", "");
     if (hash.length && hash.substring(0, 5) === "popup" 
             && document.getElementById(hash) !== null) {
-        window.onload = function () {
+        window.addEventListener("load", function () {
             expandcontract(hash, true);
-        }
+        });
     }
 }
 ec_openFirst();


### PR DESCRIPTION
The window.onload event might already be set by CMSimple_XH via `$onload`, and we must not override that.  Instead we're attaching our own event listener.

---

I'm wonder why that hasn't reported so far. Clearly a bug.