### PR TITLE
Avoid HTML attribute event handlers

### DIFF
--- a/expandcontract.js
+++ b/expandcontract.js
@@ -105,3 +105,12 @@ function ec_openFromHash() {
 ec_openFirst();
 ec_openFromHash();
 ec_showSearchResults();
+
+document.querySelectorAll(".expand_link").forEach(function (el) {
+    var popupId = el.dataset.popupId;
+    var closeBtn = document.querySelector("#" + popupId + " .ecCloseButton");
+    el.querySelector(".linkBtn").onclick = closeBtn.onclick = function () {
+        expandcontract(popupId);
+        return false;
+    };
+});

--- a/index.php
+++ b/index.php
@@ -206,9 +206,7 @@ function expand()
     }
     $i = 1;
     foreach ($pageNrArray as $value) {
-        $js = '" class="linkBtn" id="deeplink'.$i.$uniqueId
-                .'" onclick="expandcontract(\'popup'
-                .$i.$uniqueId.'\'); return false;';
+        $js = '" class="linkBtn" id="deeplink'.$i.$uniqueId.'" ';
         $expContent = str_replace('#CMSimple hide#', '', $c[$value]);
         if ($usebuttons) { 
             $o .= '<form method="post" class="expand_button" action="?' 
@@ -217,7 +215,7 @@ function expand()
             $o .=  '"></form>';
         } else {
             if (!$link) {
-                $t .= '<p class="expand_link">';
+                $t .= '<p class="expand_link" data-popup-id="popup'.$i.$uniqueId.'">';
             }
             $t .= a($value,$js);
             $t .= !empty($headlineArray[$i]) ? $headlineArray[$i] : $h[$value];
@@ -243,9 +241,8 @@ function expand()
         }
         if ($closebutton) {
             $t .= '<div class="ecClose">'
-                    . '<button class="ecCloseButton" type="button" '
-                    . 'onclick="expandcontract(\'popup' . $i.$uniqueId . '\'); '
-                    . 'return false;">' . $plugin_tx['expandcontract']['close'] 
+                    . '<button class="ecCloseButton" type="button">'
+                    . $plugin_tx['expandcontract']['close'] 
                     . '</button>'
                     . '</div>';
         }


### PR DESCRIPTION
Besides that these are mixing JS in HTML what is harder to understand and debug, they might simply not work if respective CSP is in place.

So we attach the handlers from JS instead.