### PR TITLE
Fix #16: SEO Duplicate Content (page included)

### DIFF
--- a/expandcontract.js
+++ b/expandcontract.js
@@ -108,6 +108,10 @@ ec_openFirst();
 ec_openFromHash();
 ec_showSearchResults();
 
+document.querySelectorAll(".linkBtn").forEach(function (a) {
+    a.href = "#";
+});
+
 document.querySelectorAll(".expand_link").forEach(function (el) {
     var popupId = el.dataset.popupId;
     var closeBtn = document.querySelector("#" + popupId + " .ecCloseButton");


### PR DESCRIPTION
If JS is involved, we remove the link to the hidden page, replacing it with an empty fragment.  This way, the anchor elements are still accessible with the keyboard, and search engines will not see the URLs of the hidden pages.

---

I think this solves the SEO issue, but the expandcontract widget is not really accessible – keyboard navigation barely works (you tab through the hidden buttons), and screen readers are unlikely to be able to understand the widgets. Instead of fixing this with a set of aria- attributes, using [`<details>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details) might be the simpler solution.